### PR TITLE
TODO: page counter starts at 1 instead of 0, fix bibliography numbering issue

### DIFF
--- a/jku.typ
+++ b/jku.typ
@@ -317,18 +317,6 @@
     )
   }
   
-  if zusammenfassung != [] {
-    pagebreak()
-    heading(outlined: false)[Zusammenfassung]
-    zusammenfassung
-  }
-
-  if abstract != [] {
-    pagebreak()
-    heading(outlined: false)[Abstract]
-    abstract
-  }
-
   pagebreak()
 
   if tableOfContents {
@@ -349,6 +337,20 @@
                   .map(def => [/ #def.long (#def.abbr): #def.desc])
                   .fold([], (sum, it) => sum + it)
   }
+
+    if zusammenfassung != [] {
+    pagebreak()
+    heading(outlined: false)[Zusammenfassung]
+    zusammenfassung
+  }
+
+  if abstract != [] {
+    pagebreak()
+    heading(outlined: false)[Abstract]
+    abstract
+  }
+
+  pagebreak()
   
   body
 }

--- a/jku.typ
+++ b/jku.typ
@@ -215,7 +215,7 @@
   page-margin: (left: 2.9cm, right: 2.9cm, top: 3cm, bottom: 3cm),
   body
 ) = {
-  counter(page).update(0)
+  counter(page).update(1)
   set page(
     "a4",
     margin: page-margin,
@@ -316,7 +316,7 @@
       ]
     )
   }
-  
+
   pagebreak()
 
   if tableOfContents {
@@ -364,7 +364,7 @@
   page-margin: (left: 3.2cm, right: 3.2cm, top: 3.8cm, bottom: 2.5cm),
   body
 ) = {
-  counter(page).update(0)
+  counter(page).update(1)
 
   // Page setup
   set page(


### PR DESCRIPTION
- Most JKU templates place the TOC before the abstracts, therefore the positioning in the template was also adjusted
- Page counter now starts at 1 instead of 0 to align more with other academic work