### PR TITLE
Fix 0 indexing, incorrect chapter numbering header

### DIFF
--- a/jku.typ
+++ b/jku.typ
@@ -215,7 +215,7 @@
   page-margin: (left: 2.9cm, right: 2.9cm, top: 3cm, bottom: 3cm),
   body
 ) = {
-  counter(page).update(0)
+  counter(page).update(1)
   set page(
     "a4",
     margin: page-margin,

--- a/main.typ
+++ b/main.typ
@@ -46,11 +46,13 @@
 #show bibliography: set text(size: 8pt)
 #show link: it => box(clip: true, it)
 
-#bibliography("bibliograhpy.bib")
+#counter(heading.where(level: 1)).update(it => 0) // workaround for header, to NOT show an incorrect numbering at the bibliography
+#counter(heading).update(0)
+#bibliography("bibliography.bib")
 
-#show_endnotes()
+#show_endnotes() //Comment this out if you have no endnotes
 
-#counter(heading.where(level: 1)).update(it => 0) // workaround for header
+#counter(heading.where(level: 1)).update(it => 0) // workaround for header, to NOT show an incorrect numbering at the bibliography
 #counter(heading).update(0)
 #pagebreak(weak: true)
 


### PR DESCRIPTION
**fix issue with the numbers to start at 0, not 1**
- Bibliography now does NOT show a chapter number in the header
- This is done by a reset of the chapter counter, which triggers some code that does not put the chapter number in front of the name. This is the same behaviour as with the preface (everything before the main body content)

**fix issue with the numbers to start at 0, not 1**
- Obviously, many things in IT do start with indexing at 0, however in the academic work, I think it is more appropriate to start at 1 to more align with other work